### PR TITLE
Fix various and sundry python 3 bytes/str issues

### DIFF
--- a/lib/activedirectory/core/client.py
+++ b/lib/activedirectory/core/client.py
@@ -137,9 +137,9 @@ class Client(object):
         finally:
             conn.unbind_s()
         dn, attrs = result[0]
-        self.m_forest = attrs['rootDomainNamingContext'][0]
-        self.m_schema = attrs['schemaNamingContext'][0]
-        self.m_configuration = attrs['configurationNamingContext'][0]
+        self.m_forest = attrs['rootDomainNamingContext'][0].decode('utf-8')
+        self.m_schema = attrs['schemaNamingContext'][0].decode('utf-8')
+        self.m_configuration = attrs['configurationNamingContext'][0].decode('utf-8')
 
     def domain(self):
         """Return the domain name of the current domain."""
@@ -193,7 +193,7 @@ class Client(object):
         naming_contexts = []
         for res in result:
             dn, attrs = res
-            nc = attrs['nCName'][0].lower()
+            nc = attrs['nCName'][0].decode('utf-8').lower()
             naming_contexts.append(nc)
         self.m_naming_contexts = naming_contexts
 

--- a/lib/activedirectory/protocol/asn1.py
+++ b/lib/activedirectory/protocol/asn1.py
@@ -59,7 +59,7 @@ class Encoder(object):
             raise Error('Encoder not initialized. Call start() first.')
         if len(self.m_stack) == 1:
             raise Error('Tag stack is empty.')
-        value = ''.join(self.m_stack[-1])
+        value = b''.join(self.m_stack[-1])
         del self.m_stack[-1]
         self._emit_length(len(value))
         self._emit(value)
@@ -73,6 +73,8 @@ class Encoder(object):
                 nr = Integer
             elif isinstance(value, six.string_types):
                 nr = OctetString
+                if isinstance(value, six.text_type):
+                    value = value.encode('utf-8')
             elif value is None:
                 nr = Null
         if typ is None:
@@ -90,7 +92,7 @@ class Encoder(object):
             raise Error('Encoder not initialized. Call start() first.')
         if len(self.m_stack) != 1:
             raise Error('Stack is not empty.')
-        output = ''.join(self.m_stack[0])
+        output = b''.join(self.m_stack[0])
         return output
 
     def _emit_tag(self, nr, typ, cls):
@@ -103,11 +105,11 @@ class Encoder(object):
     def _emit_tag_short(self, nr, typ, cls):
         """Emit a short (< 31 bytes) tag."""
         assert nr < 31
-        self._emit(chr(nr | typ | cls))
+        self._emit(six.int2byte(nr | typ | cls))
 
     def _emit_tag_long(self, nr, typ, cls):
         """Emit a long (>= 31 bytes) tag."""
-        head = chr(typ | cls | 0x1f)
+        head = six.int2byte(typ | cls | 0x1f)
         self._emit(head)
         values = []
         values.append((nr & 0x7f))
@@ -116,7 +118,7 @@ class Encoder(object):
             values.append((nr & 0x7f) | 0x80)
             nr >>= 7
         values.reverse()
-        values = list(map(chr, values))
+        values = list(map(six.int2byte, values))
         for val in values:
             self._emit(val)
 
@@ -130,7 +132,7 @@ class Encoder(object):
     def _emit_length_short(self, length):
         """Emit the short length form (< 128 octets)."""
         assert length < 128
-        self._emit(chr(length))
+        self._emit(six.int2byte(length))
 
     def _emit_length_long(self, length):
         """Emit the long length form (>= 128 octets)."""
@@ -139,17 +141,17 @@ class Encoder(object):
             values.append(length & 0xff)
             length >>= 8
         values.reverse()
-        values = list(map(chr, values))
+        values = list(map(six.int2byte, values))
         # really for correctness as this should not happen anytime soon
         assert len(values) < 127
-        head = chr(0x80 | len(values))
+        head = six.int2byte(0x80 | len(values))
         self._emit(head)
         for val in values:
             self._emit(val)
 
     def _emit(self, s):
         """Emit raw bytes."""
-        assert isinstance(s, str)
+        assert isinstance(s, six.binary_type)
         self.m_stack[-1].append(s)
 
     def _encode_value(self, nr, value):
@@ -168,7 +170,7 @@ class Encoder(object):
 
     def _encode_boolean(self, value):
         """Encode a boolean."""
-        return value and '\xff' or '\x00'
+        return value and b'\xff' or b'\x00'
 
     def _encode_integer(self, value):
         """Encode an integer."""
@@ -195,8 +197,8 @@ class Encoder(object):
                 assert i != len(values)-1
                 values[i] = 0x00
         values.reverse()
-        values = list(map(chr, values))
-        return ''.join(values)
+        values = list(map(six.int2byte, values))
+        return b''.join(values)
 
     def _encode_octet_string(self, value):
         """Encode an octetstring."""
@@ -205,7 +207,7 @@ class Encoder(object):
 
     def _encode_null(self):
         """Encode a Null value."""
-        return ''
+        return b''
 
     _re_oid = re.compile(r'^[0-9]+(\.[0-9]+)+$')
 
@@ -225,8 +227,8 @@ class Encoder(object):
                 cmp >>= 7
                 result.append(0x80 | (cmp & 0x7f))
         result.reverse()
-        result = list(map(chr, result))
-        return ''.join(result)
+        result = list(map(six.int2byte, result))
+        return b''.join(result)
 
 
 class Decoder(object):
@@ -239,8 +241,8 @@ class Decoder(object):
 
     def start(self, data):
         """Start processing `data'."""
-        if not isinstance(data, str):
-            raise Error('Expecting string instance.')
+        if not isinstance(data, six.binary_type):
+            raise Error('Expecting %s instance.' % six.binary_type.__name__)
         self.m_stack = [[0, data]]
         self.m_tag = None
 
@@ -296,9 +298,10 @@ class Decoder(object):
         """Decode a boolean value."""
         if len(bytes) != 1:
             raise Error('ASN1 syntax error')
-        if bytes[0] == '\x00':
-            return False
-        return True
+        byte = bytes[0]
+        if isinstance(byte, str):
+            byte = ord(byte)
+        return (byte != 0)
 
     def _read_tag(self):
         """Read a tag from the input."""
@@ -323,9 +326,11 @@ class Decoder(object):
             if count == 0x7f:
                 raise Error('ASN1 syntax error')
             bytes = self._read_bytes(count)
-            bytes = [ ord(b) for b in bytes ]
+            bytes = [ b for b in bytes ]
             length = 0
             for byte in bytes:
+                if isinstance(byte, str):
+                    byte = ord(byte)
                 length = (length << 8) | byte
             try:
                 length = int(length)
@@ -356,10 +361,12 @@ class Decoder(object):
         """Return the next input byte, or raise an error on end-of-input."""
         index, input = self.m_stack[-1]
         try:
-            byte = ord(input[index])
+            byte = input[index]
         except IndexError:
             raise Error('Premature end of input.')
         self.m_stack[-1][0] += 1
+        if isinstance(byte, str):
+            byte = ord(byte)
         return byte
 
     def _read_bytes(self, count):
@@ -380,7 +387,11 @@ class Decoder(object):
 
     def _decode_integer(self, bytes):
         """Decode an integer value."""
-        values = [ ord(b) for b in bytes ]
+        if six.PY2:
+            values = [ord(b) for b in bytes]
+        else:
+            values = [b for b in bytes]
+
         # check if the integer is normalized
         if len(values) > 1 and \
                 (values[0] == 0xff and values[1] & 0x80 or
@@ -423,7 +434,9 @@ class Decoder(object):
         result = []
         value = 0
         for i in range(len(bytes)):
-            byte = ord(bytes[i])
+            byte = bytes[i]
+            if isinstance(byte, str):
+                byte = ord(byte)
             if value == 0 and byte == 0x80:
                 raise Error('ASN1 syntax error')
             value = (value << 7) | (byte & 0x7f)
@@ -433,5 +446,5 @@ class Decoder(object):
         if len(result) == 0 or result[0] > 1599:
             raise Error('ASN1 syntax error')
         result = [result[0] // 40, result[0] % 40] + result[1:]
-        result = list(map(str, result))
-        return '.'.join(result)
+        result = [six.text_type(r).encode('utf-8') for r in result]
+        return b'.'.join(result)

--- a/tests/base.py
+++ b/tests/base.py
@@ -100,7 +100,7 @@ class Conf(object):
         with open(fname, 'rb') as fin:
             buf = fin.read()
 
-        return buf.decode('latin_1') if six.PY3 else buf
+        return buf
 
     def require(self, ad_user=False, local_admin=False, ad_admin=False,
                 firewall=False, expensive=False):

--- a/tests/protocol/test_asn1.py
+++ b/tests/protocol/test_asn1.py
@@ -8,6 +8,7 @@
 
 from __future__ import absolute_import
 from activedirectory.protocol import asn1
+import six
 
 from ..base import assert_raises
 
@@ -20,104 +21,104 @@ class TestEncoder(object):
         enc.start()
         enc.write(True, asn1.Boolean)
         res = enc.output()
-        assert res == '\x01\x01\xff'
+        assert res == b'\x01\x01\xff'
 
     def test_integer(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(1)
         res = enc.output()
-        assert res == '\x02\x01\x01'
+        assert res == b'\x02\x01\x01'
 
     def test_long_integer(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(0x0102030405060708090a0b0c0d0e0f)
         res = enc.output()
-        assert res == '\x02\x0f\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'
+        assert res == b'\x02\x0f\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'
 
     def test_negative_integer(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(-1)
         res = enc.output()
-        assert res == '\x02\x01\xff'
+        assert res == b'\x02\x01\xff'
 
     def test_long_negative_integer(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(-0x0102030405060708090a0b0c0d0e0f)
         res = enc.output()
-        assert res == '\x02\x0f\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf1'
+        assert res == b'\x02\x0f\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf1'
 
     def test_twos_complement_boundaries(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(127)
         res = enc.output()
-        assert res == '\x02\x01\x7f'
+        assert res == b'\x02\x01\x7f'
         enc.start()
         enc.write(128)
         res = enc.output()
-        assert res == '\x02\x02\x00\x80'
+        assert res == b'\x02\x02\x00\x80'
         enc.start()
         enc.write(-128)
         res = enc.output()
-        assert res == '\x02\x01\x80'
+        assert res == b'\x02\x01\x80'
         enc.start()
         enc.write(-129)
         res = enc.output()
-        assert res == '\x02\x02\xff\x7f'
+        assert res == b'\x02\x02\xff\x7f'
 
     def test_octet_string(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write('foo')
         res = enc.output()
-        assert res == '\x04\x03foo'
+        assert res == b'\x04\x03foo'
 
     def test_null(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(None)
         res = enc.output()
-        assert res == '\x05\x00'
+        assert res == b'\x05\x00'
 
     def test_object_identifier(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write('1.2.3', asn1.ObjectIdentifier)
         res = enc.output()
-        assert res == '\x06\x02\x2a\x03'
+        assert res == b'\x06\x02\x2a\x03'
 
     def test_long_object_identifier(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write('39.2.3', asn1.ObjectIdentifier)
         res = enc.output()
-        assert res == '\x06\x03\x8c\x1a\x03'
+        assert res == b'\x06\x03\x8c\x1a\x03'
         enc.start()
         enc.write('1.39.3', asn1.ObjectIdentifier)
         res = enc.output()
-        assert res == '\x06\x02\x4f\x03'
+        assert res == b'\x06\x02\x4f\x03'
         enc.start()
         enc.write('1.2.300000', asn1.ObjectIdentifier)
         res = enc.output()
-        assert res == '\x06\x04\x2a\x92\xa7\x60'
+        assert res == b'\x06\x04\x2a\x92\xa7\x60'
 
     def test_real_object_identifier(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write('1.2.840.113554.1.2.1.1', asn1.ObjectIdentifier)
         res = enc.output()
-        assert res == '\x06\x0a\x2a\x86\x48\x86\xf7\x12\x01\x02\x01\x01'
+        assert res == b'\x06\x0a\x2a\x86\x48\x86\xf7\x12\x01\x02\x01\x01'
 
     def test_enumerated(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write(1, asn1.Enumerated)
         res = enc.output()
-        assert res == '\x0a\x01\x01'
+        assert res == b'\x0a\x01\x01'
 
     def test_sequence(self):
         enc = asn1.Encoder()
@@ -127,7 +128,7 @@ class TestEncoder(object):
         enc.write('foo')
         enc.leave()
         res = enc.output()
-        assert res == '\x30\x08\x02\x01\x01\x04\x03foo'
+        assert res == b'\x30\x08\x02\x01\x01\x04\x03foo'
 
     def test_sequence_of(self):
         enc = asn1.Encoder()
@@ -137,7 +138,7 @@ class TestEncoder(object):
         enc.write(2)
         enc.leave()
         res = enc.output()
-        assert res == '\x30\x06\x02\x01\x01\x02\x01\x02'
+        assert res == b'\x30\x06\x02\x01\x01\x02\x01\x02'
 
     def test_set(self):
         enc = asn1.Encoder()
@@ -147,7 +148,7 @@ class TestEncoder(object):
         enc.write('foo')
         enc.leave()
         res = enc.output()
-        assert res == '\x31\x08\x02\x01\x01\x04\x03foo'
+        assert res == b'\x31\x08\x02\x01\x01\x04\x03foo'
 
     def test_set_of(self):
         enc = asn1.Encoder()
@@ -157,7 +158,7 @@ class TestEncoder(object):
         enc.write(2)
         enc.leave()
         res = enc.output()
-        assert res == '\x31\x06\x02\x01\x01\x02\x01\x02'
+        assert res == b'\x31\x06\x02\x01\x01\x02\x01\x02'
 
     def test_context(self):
         enc = asn1.Encoder()
@@ -166,7 +167,7 @@ class TestEncoder(object):
         enc.write(1)
         enc.leave()
         res = enc.output()
-        assert res == '\xa1\x03\x02\x01\x01'
+        assert res == b'\xa1\x03\x02\x01\x01'
 
     def test_application(self):
         enc = asn1.Encoder()
@@ -175,7 +176,7 @@ class TestEncoder(object):
         enc.write(1)
         enc.leave()
         res = enc.output()
-        assert res == '\x61\x03\x02\x01\x01'
+        assert res == b'\x61\x03\x02\x01\x01'
 
     def test_private(self):
         enc = asn1.Encoder()
@@ -184,7 +185,7 @@ class TestEncoder(object):
         enc.write(1)
         enc.leave()
         res = enc.output()
-        assert res == '\xe1\x03\x02\x01\x01'
+        assert res == b'\xe1\x03\x02\x01\x01'
 
     def test_long_tag_id(self):
         enc = asn1.Encoder()
@@ -193,14 +194,14 @@ class TestEncoder(object):
         enc.write(1)
         enc.leave()
         res = enc.output()
-        assert res == '\x3f\x83\xff\x7f\x03\x02\x01\x01'
+        assert res == b'\x3f\x83\xff\x7f\x03\x02\x01\x01'
 
     def test_long_tag_length(self):
         enc = asn1.Encoder()
         enc.start()
         enc.write('x' * 0xffff)
         res = enc.output()
-        assert res == '\x04\x82\xff\xff' + 'x' * 0xffff
+        assert res == b'\x04\x82\xff\xff' + b'x' * 0xffff
 
     def test_error_init(self):
         enc = asn1.Encoder()
@@ -234,7 +235,7 @@ class TestDecoder(object):
     """Test suite for ASN1 Decoder."""
 
     def test_boolean(self):
-        buf = '\x01\x01\xff'
+        buf = b'\x01\x01\xff'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -242,19 +243,19 @@ class TestDecoder(object):
         tag, val = dec.read()
         assert isinstance(val, int)
         assert val == True
-        buf = '\x01\x01\x01'
+        buf = b'\x01\x01\x01'
         dec.start(buf)
         tag, val = dec.read()
         assert isinstance(val, int)
         assert val == True
-        buf = '\x01\x01\x00'
+        buf = b'\x01\x01\x00'
         dec.start(buf)
         tag, val = dec.read()
         assert isinstance(val, int)
         assert val == False
 
     def test_integer(self):
-        buf = '\x02\x01\x01'
+        buf = b'\x02\x01\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -264,57 +265,57 @@ class TestDecoder(object):
         assert val == 1
 
     def test_long_integer(self):
-        buf = '\x02\x0f\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'
+        buf = b'\x02\x0f\x01\x02\x03\x04\x05\x06\x07\x08\x09\x0a\x0b\x0c\x0d\x0e\x0f'
         dec = asn1.Decoder()
         dec.start(buf)
         tag, val = dec.read()
         assert val == 0x0102030405060708090a0b0c0d0e0f
 
     def test_negative_integer(self):
-        buf = '\x02\x01\xff'
+        buf = b'\x02\x01\xff'
         dec = asn1.Decoder()
         dec.start(buf)
         tag, val = dec.read()
         assert val == -1
 
     def test_long_negative_integer(self):
-        buf = '\x02\x0f\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf1'
+        buf = b'\x02\x0f\xfe\xfd\xfc\xfb\xfa\xf9\xf8\xf7\xf6\xf5\xf4\xf3\xf2\xf1\xf1'
         dec = asn1.Decoder()
         dec.start(buf)
         tag, val = dec.read()
         assert val == -0x0102030405060708090a0b0c0d0e0f
 
     def test_twos_complement_boundaries(self):
-        buf = '\x02\x01\x7f'
+        buf = b'\x02\x01\x7f'
         dec = asn1.Decoder()
         dec.start(buf)
         tag, val = dec.read()
         assert val == 127
-        buf = '\x02\x02\x00\x80'
+        buf = b'\x02\x02\x00\x80'
         dec.start(buf)
         tag, val = dec.read()
         assert val == 128
-        buf = '\x02\x01\x80'
+        buf = b'\x02\x01\x80'
         dec.start(buf)
         tag, val = dec.read()
         assert val == -128
-        buf = '\x02\x02\xff\x7f'
+        buf = b'\x02\x02\xff\x7f'
         dec.start(buf)
         tag, val = dec.read()
         assert val == -129
 
     def test_octet_string(self):
-        buf = '\x04\x03foo'
+        buf = b'\x04\x03foo'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.OctetString, asn1.TypePrimitive, asn1.ClassUniversal)
         tag, val = dec.read()
-        assert isinstance(val, str)
-        assert val == 'foo'
+        assert isinstance(val, six.binary_type)
+        assert val == b'foo'
 
     def test_null(self):
-        buf = '\x05\x00'
+        buf = b'\x05\x00'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -324,38 +325,38 @@ class TestDecoder(object):
 
     def test_object_identifier(self):
         dec = asn1.Decoder()
-        buf = '\x06\x02\x2a\x03'
+        buf = b'\x06\x02\x2a\x03'
         dec.start(buf)
         tag = dec.peek()
         assert tag == (asn1.ObjectIdentifier, asn1.TypePrimitive,
                        asn1.ClassUniversal)
         tag, val = dec.read()
-        assert val == '1.2.3'
+        assert val == b'1.2.3'
 
     def test_long_object_identifier(self):
         dec = asn1.Decoder()
-        buf = '\x06\x03\x8c\x1a\x03'
+        buf = b'\x06\x03\x8c\x1a\x03'
         dec.start(buf)
         tag, val = dec.read()
-        assert val == '39.2.3'
-        buf = '\x06\x02\x4f\x03'
+        assert val == b'39.2.3'
+        buf = b'\x06\x02\x4f\x03'
         dec.start(buf)
         tag, val = dec.read()
-        assert val == '1.39.3'
-        buf = '\x06\x04\x2a\x92\xa7\x60'
+        assert val == b'1.39.3'
+        buf = b'\x06\x04\x2a\x92\xa7\x60'
         dec.start(buf)
         tag, val = dec.read()
-        assert val == '1.2.300000'
+        assert val == b'1.2.300000'
 
     def test_real_object_identifier(self):
         dec = asn1.Decoder()
-        buf = '\x06\x0a\x2a\x86\x48\x86\xf7\x12\x01\x02\x01\x01'
+        buf = b'\x06\x0a\x2a\x86\x48\x86\xf7\x12\x01\x02\x01\x01'
         dec.start(buf)
         tag, val = dec.read()
-        assert val == '1.2.840.113554.1.2.1.1'
+        assert val == b'1.2.840.113554.1.2.1.1'
 
     def test_enumerated(self):
-        buf = '\x0a\x01\x01'
+        buf = b'\x0a\x01\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -365,7 +366,7 @@ class TestDecoder(object):
         assert val == 1
 
     def test_sequence(self):
-        buf = '\x30\x08\x02\x01\x01\x04\x03foo'
+        buf = b'\x30\x08\x02\x01\x01\x04\x03foo'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -374,10 +375,10 @@ class TestDecoder(object):
         tag, val = dec.read()
         assert val == 1
         tag, val = dec.read()
-        assert val == 'foo'
+        assert val == b'foo'
 
     def test_sequence_of(self):
-        buf = '\x30\x06\x02\x01\x01\x02\x01\x02'
+        buf = b'\x30\x06\x02\x01\x01\x02\x01\x02'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -389,7 +390,7 @@ class TestDecoder(object):
         assert val == 2
 
     def test_set(self):
-        buf = '\x31\x08\x02\x01\x01\x04\x03foo'
+        buf = b'\x31\x08\x02\x01\x01\x04\x03foo'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -398,10 +399,10 @@ class TestDecoder(object):
         tag, val = dec.read()
         assert val == 1
         tag, val = dec.read()
-        assert val == 'foo'
+        assert val == b'foo'
 
     def test_set_of(self):
-        buf = '\x31\x06\x02\x01\x01\x02\x01\x02'
+        buf = b'\x31\x06\x02\x01\x01\x02\x01\x02'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -413,7 +414,7 @@ class TestDecoder(object):
         assert val == 2
 
     def test_context(self):
-        buf = '\xa1\x03\x02\x01\x01'
+        buf = b'\xa1\x03\x02\x01\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -423,7 +424,7 @@ class TestDecoder(object):
         assert val == 1
 
     def test_application(self):
-        buf = '\x61\x03\x02\x01\x01'
+        buf = b'\x61\x03\x02\x01\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -433,7 +434,7 @@ class TestDecoder(object):
         assert val == 1
 
     def test_private(self):
-        buf = '\xe1\x03\x02\x01\x01'
+        buf = b'\xe1\x03\x02\x01\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -443,7 +444,7 @@ class TestDecoder(object):
         assert val == 1
 
     def test_long_tag_id(self):
-        buf = '\x3f\x83\xff\x7f\x03\x02\x01\x01'
+        buf = b'\x3f\x83\xff\x7f\x03\x02\x01\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         tag = dec.peek()
@@ -453,14 +454,14 @@ class TestDecoder(object):
         assert val == 1
 
     def test_long_tag_length(self):
-        buf = '\x04\x82\xff\xff' + 'x' * 0xffff
+        buf = b'\x04\x82\xff\xff' + b'x' * 0xffff
         dec = asn1.Decoder()
         dec.start(buf)
         tag, val = dec.read()
-        assert val == 'x' * 0xffff
+        assert val == b'x' * 0xffff
 
     def test_read_multiple(self):
-        buf = '\x02\x01\x01\x02\x01\x02'
+        buf = b'\x02\x01\x01\x02\x01\x02'
         dec = asn1.Decoder()
         dec.start(buf)
         tag, val = dec.read()
@@ -470,7 +471,7 @@ class TestDecoder(object):
         assert dec.eof()
 
     def test_skip_primitive(self):
-        buf = '\x02\x01\x01\x02\x01\x02'
+        buf = b'\x02\x01\x01\x02\x01\x02'
         dec = asn1.Decoder()
         dec.start(buf)
         dec.read()
@@ -479,7 +480,7 @@ class TestDecoder(object):
         assert dec.eof()
 
     def test_skip_constructed(self):
-        buf = '\x30\x06\x02\x01\x01\x02\x01\x02\x02\x01\x03'
+        buf = b'\x30\x06\x02\x01\x01\x02\x01\x02\x02\x01\x03'
         dec = asn1.Decoder()
         dec.start(buf)
         dec.read()
@@ -495,7 +496,7 @@ class TestDecoder(object):
         assert_raises(asn1.Error, dec.leave)
 
     def test_error_stack(self):
-        buf = '\x30\x08\x02\x01\x01\x04\x03foo'
+        buf = b'\x30\x08\x02\x01\x01\x04\x03foo'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.leave)
@@ -505,69 +506,69 @@ class TestDecoder(object):
 
     def test_no_input(self):
         dec = asn1.Decoder()
-        dec.start('')
+        dec.start(b'')
         tag = dec.peek()
         assert tag is None
 
     def test_error_missing_tag_bytes(self):
-        buf = '\x3f'
+        buf = b'\x3f'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.peek)
-        buf = '\x3f\x83'
+        buf = b'\x3f\x83'
         dec.start(buf)
         assert_raises(asn1.Error, dec.peek)
 
     def test_error_no_length_bytes(self):
-        buf = '\x02'
+        buf = b'\x02'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_missing_length_bytes(self):
-        buf = '\x04\x82\xff'
+        buf = b'\x04\x82\xff'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_too_many_length_bytes(self):
-        buf = '\x04\xff' + '\xff' * 0x7f
+        buf = b'\x04\xff' + b'\xff' * 0x7f
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_no_value_bytes(self):
-        buf = '\x02\x01'
+        buf = b'\x02\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_missing_value_bytes(self):
-        buf = '\x02\x02\x01'
+        buf = b'\x02\x02\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_non_normalized_positive_integer(self):
-        buf = '\x02\x02\x00\x01'
+        buf = b'\x02\x02\x00\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_non_normalized_negative_integer(self):
-        buf = '\x02\x02\xff\x80'
+        buf = b'\x02\x02\xff\x80'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_non_normalised_object_identifier(self):
-        buf = '\x06\x02\x80\x01'
+        buf = b'\x06\x02\x80\x01'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)
 
     def test_error_object_identifier_with_too_large_first_component(self):
-        buf = '\x06\x02\x8c\x40'
+        buf = b'\x06\x02\x8c\x40'
         dec = asn1.Decoder()
         dec.start(buf)
         assert_raises(asn1.Error, dec.read)

--- a/tests/protocol/test_ldap.py
+++ b/tests/protocol/test_ldap.py
@@ -31,9 +31,9 @@ def test_decode_real_search_reply(conf):
     assert len(reply) == 1
     msgid, dn, attrs = reply[0]
     assert msgid == 4
-    assert dn == ''
+    assert dn == b''
 
     netlogon = conf.read_file('protocol/netlogon.bin')
     print(repr(attrs))
     print(repr({ 'netlogon': [netlogon] }))
-    assert attrs == { 'netlogon': [netlogon] }
+    assert attrs == { b'netlogon': [netlogon] }

--- a/tests/protocol/test_netlogon.py
+++ b/tests/protocol/test_netlogon.py
@@ -39,121 +39,121 @@ class TestDecoder(object):
     """Test suite for netlogon.Decoder."""
 
     def test_uint32_simple(self):
-        s = '\x01\x00\x00\x00'
+        s = b'\x01\x00\x00\x00'
         assert decode_uint32(s, 0) == (1, 4)
 
     def test_uint32_byte_order(self):
-        s = '\x00\x01\x00\x00'
+        s = b'\x00\x01\x00\x00'
         assert decode_uint32(s, 0) == (0x100, 4)
-        s = '\x00\x00\x01\x00'
+        s = b'\x00\x00\x01\x00'
         assert decode_uint32(s, 0) == (0x10000, 4)
-        s = '\x00\x00\x00\x01'
+        s = b'\x00\x00\x00\x01'
         assert decode_uint32(s, 0) == (0x1000000, 4)
 
     def test_uint32_long(self):
-        s = '\x00\x00\x00\xff'
+        s = b'\x00\x00\x00\xff'
         assert decode_uint32(s, 0) == (0xff000000, 4)
-        s = '\xff\xff\xff\xff'
+        s = b'\xff\xff\xff\xff'
         assert decode_uint32(s, 0) == (0xffffffff, 4)
 
     def test_error_uint32_null_input(self):
-        s = ''
+        s = b''
         assert_raises(netlogon.Error, decode_uint32, s, 0)
 
     def test_error_uint32_short_input(self):
-        s = '\x00'
+        s = b'\x00'
         assert_raises(netlogon.Error, decode_uint32, s, 0)
-        s = '\x00\x00'
+        s = b'\x00\x00'
         assert_raises(netlogon.Error, decode_uint32, s, 0)
-        s = '\x00\x00\x00'
+        s = b'\x00\x00\x00'
         assert_raises(netlogon.Error, decode_uint32, s, 0)
 
     def test_rfc1035_simple(self):
-        s = '\x03foo\x00'
-        assert decode_rfc1035(s, 0) == ('foo', 5)
+        s = b'\x03foo\x00'
+        assert decode_rfc1035(s, 0) == (b'foo', 5)
 
     def test_rfc1035_multi_component(self):
-        s = '\x03foo\x03bar\x00'
-        assert decode_rfc1035(s, 0) == ('foo.bar', 9)
+        s = b'\x03foo\x03bar\x00'
+        assert decode_rfc1035(s, 0) == (b'foo.bar', 9)
 
     def test_rfc1035_pointer(self):
-        s = '\x03foo\x00\xc0\x00'
-        assert decode_rfc1035(s, 5) == ('foo', 7)
+        s = b'\x03foo\x00\xc0\x00'
+        assert decode_rfc1035(s, 5) == (b'foo', 7)
 
     def test_rfc1035_forward_pointer(self):
-        s = '\xc0\x02\x03foo\x00'
-        assert decode_rfc1035(s, 0) == ('foo', 2)
+        s = b'\xc0\x02\x03foo\x00'
+        assert decode_rfc1035(s, 0) == (b'foo', 2)
 
     def test_rfc1035_pointer_component(self):
-        s = '\x03foo\x00\x03bar\xc0\x00'
-        assert decode_rfc1035(s, 5) == ('bar.foo', 11)
+        s = b'\x03foo\x00\x03bar\xc0\x00'
+        assert decode_rfc1035(s, 5) == (b'bar.foo', 11)
 
     def test_rfc1035_pointer_multi_component(self):
-        s = '\x03foo\x03bar\x00\x03baz\xc0\x00'
-        assert decode_rfc1035(s, 9) == ('baz.foo.bar', 15)
+        s = b'\x03foo\x03bar\x00\x03baz\xc0\x00'
+        assert decode_rfc1035(s, 9) == (b'baz.foo.bar', 15)
 
     def test_rfc1035_pointer_recursive(self):
-        s = '\x03foo\x00\x03bar\xc0\x00\x03baz\xc0\x05'
-        assert decode_rfc1035(s, 11) == ('baz.bar.foo', 17)
+        s = b'\x03foo\x00\x03bar\xc0\x00\x03baz\xc0\x05'
+        assert decode_rfc1035(s, 11) == (b'baz.bar.foo', 17)
 
     def test_rfc1035_multi_string(self):
-        s = '\x03foo\x00\x03bar\x00'
-        assert decode_rfc1035(s, 0) == ('foo', 5)
-        assert decode_rfc1035(s, 5) == ('bar', 10)
+        s = b'\x03foo\x00\x03bar\x00'
+        assert decode_rfc1035(s, 0) == (b'foo', 5)
+        assert decode_rfc1035(s, 5) == (b'bar', 10)
 
     def test_rfc1035_null(self):
-        s = '\x00'
-        assert decode_rfc1035(s, 0) == ('', 1)
+        s = b'\x00'
+        assert decode_rfc1035(s, 0) == (b'', 1)
 
     def test_error_rfc1035_null_input(self):
-        s = ''
+        s = b''
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_error_rfc1035_missing_tag(self):
-        s = '\x03foo'
+        s = b'\x03foo'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_error_rfc1035_truncated_input(self):
-        s = '\x04foo'
+        s = b'\x04foo'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_error_rfc1035_pointer_overflow(self):
-        s = '\xc0\x03'
+        s = b'\xc0\x03'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_error_rfc1035_cyclic_pointer(self):
-        s = '\xc0\x00'
+        s = b'\xc0\x00'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
-        s = '\x03foo\xc0\x06\x03bar\xc0\x0c\x03baz\xc0\x00'
+        s = b'\x03foo\xc0\x06\x03bar\xc0\x0c\x03baz\xc0\x00'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_error_rfc1035_illegal_tags(self):
-        s = '\x80' + 0x80 * 'a' + '\x00'
+        s = b'\x80' + 0x80 * b'a' + b'\x00'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
-        s = '\x40' + 0x40 * 'a' + '\x00'
+        s = b'\x40' + 0x40 * b'a' + b'\x00'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_error_rfc1035_half_pointer(self):
-        s = '\xc0'
+        s = b'\xc0'
         assert_raises(netlogon.Error, decode_rfc1035, s, 0)
 
     def test_io_byte(self):
         d = netlogon.Decoder()
-        s = 'foo'
+        s = b'foo'
         d.start(s)
-        assert d._read_byte() == 'f'
-        assert d._read_byte() == 'o'
-        assert d._read_byte() == 'o'
+        assert d._read_byte() == ord('f')
+        assert d._read_byte() == ord('o')
+        assert d._read_byte() == ord('o')
 
     def test_io_bytes(self):
         d = netlogon.Decoder()
-        s = 'foo'
+        s = b'foo'
         d.start(s)
-        assert d._read_bytes(3) == 'foo'
+        assert d._read_bytes(3) == b'foo'
 
     def test_error_io_byte(self):
         d = netlogon.Decoder()
-        s = 'foo'
+        s = b'foo'
         d.start(s)
         for i in range(3):
             d._read_byte()
@@ -161,13 +161,13 @@ class TestDecoder(object):
 
     def test_error_io_bytes(self):
         d = netlogon.Decoder()
-        s = 'foo'
+        s = b'foo'
         d.start(s)
         assert_raises(netlogon.Error, d._read_bytes, 4)
 
     def test_error_io_bounds(self):
         d = netlogon.Decoder()
-        s = 'foo'
+        s = b'foo'
         d.start(s)
         d._set_offset(4)
         assert_raises(netlogon.Error, d._read_byte)
@@ -175,7 +175,7 @@ class TestDecoder(object):
 
     def test_error_negative_offset(self):
         d = netlogon.Decoder()
-        s = 'foo'
+        s = b'foo'
         d.start(s)
         assert_raises(netlogon.Error, d._set_offset, -1)
 
@@ -186,23 +186,20 @@ class TestDecoder(object):
         assert_raises(netlogon.Error, d.start, ())
         assert_raises(netlogon.Error, d.start, [])
         assert_raises(netlogon.Error, d.start, {})
-        if six.PY3:
-            assert_raises(netlogon.Error, d.start, b'test')
-        else:
-            assert_raises(netlogon.Error, d.start, u'test')
+        assert_raises(netlogon.Error, d.start, u'test')
 
     def test_real_packet(self, conf):
         buf = conf.read_file('protocol/netlogon.bin')
         dec = netlogon.Decoder()
         dec.start(buf)
         res = dec.parse()
-        assert res.forest == 'freeadi.org'
-        assert res.domain == 'freeadi.org'
-        assert res.client_site == 'Default-First-Site'
-        assert res.server_site == 'Test-Site'
+        assert res.forest == b'freeadi.org'
+        assert res.domain == b'freeadi.org'
+        assert res.client_site == b'Default-First-Site'
+        assert res.server_site == b'Test-Site'
 
     def test_error_short_input(self):
-        buf = 'x' * 24
+        buf = b'x' * 24
         dec = netlogon.Decoder()
         dec.start(buf)
         assert_raises(netlogon.Error, dec.parse)


### PR DESCRIPTION
`activedirectory.protocol.asn1` was operating with `str` in python 3; this was resulting in a different value being passed to the socket in python 2 and 3, since `six.ensure_text` on the asn1 encoded buffer returned different results. All protocol modules now use bytes.

I also added the ability to set a custom `dns.resolver.Resolver` instance on the `activedirectory.core.locate.Locator` singleton, so that custom nameservers can be used to perform the `SRV` DNS queries.

fixes FUN-2111